### PR TITLE
Update readme.md with simplified spi enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ lora.set_mode(MODE.STDBY)
 ```
 Registers are queried like so:
 ```python
-print lora.version()        # this prints the sx127x chip version
+print lora.get_version()        # this prints the sx127x chip version
 print lora.get_freq()       # this prints the frequency setting 
 ```
 and setting registers is easy, too

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ It supports Python 3 or newer and PyPy. https://pypi.org/project/pyLoRa/
 
 ## Easy setup on Raspberry Pi:
 ```bash
-sudo raspi-config
--- Interfacing Options
---- enable SPI
+sudo raspi-config nonint do_spi 0
 sudo apt-get install python-dev python3-dev
 ```
 


### PR DESCRIPTION
Since there is a way to enable SPI without user navigating through "terminal gui" hence I think that would be easier to just copy-paste another command :)

The way it works is that under the hood `raspi-config` calls noint commands, so we can use that instead. [Here is an SPI example](https://github.com/raspberrypi-ui/rc_gui/blob/master/src/rc_gui.c#L76)